### PR TITLE
Ledger, PID, opencrypto-weight update

### DIFF
--- a/build/deref/asset.json
+++ b/build/deref/asset.json
@@ -2,11 +2,12 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://schema.opencrypto.io/models/asset#",
   "title": "Asset",
-  "description": "Cryptocurrency - digital asset (blockchain or token).",
+  "description": "Cryptocurrency - digital asset (native or token).",
   "type": "object",
   "required": [
     "name",
-    "type"
+    "type",
+    "ledger"
   ],
   "properties": {
     "id": {
@@ -14,15 +15,11 @@
       "description": "Unique identifier (to be written in small letters - for internal usage only).",
       "type": "string"
     },
-    "type": {
-      "title": "Type",
-      "description": "Type of asset, eq. blockchain or token.",
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
       "type": "string",
-      "enum": [
-        "blockchain",
-        "token"
-      ],
-      "opencrypto-weight": 1
+      "opencrypto-generated": true
     },
     "name": {
       "title": "Name",
@@ -30,232 +27,39 @@
       "type": "string",
       "opencrypto-weight": 1
     },
+    "type": {
+      "title": "Type",
+      "description": "Type of asset, eq. native or token.",
+      "type": "string",
+      "enum": [
+        "native",
+        "token"
+      ],
+      "opencrypto-weight": 1
+    },
+    "ledger": {
+      "title": "Ledger",
+      "description": "Ledger where the asset is being run.",
+      "type": "string"
+    },
     "symbol": {
       "title": "Symbol",
       "description": "One to nine characters (to be written in capital letters).",
       "type": "string",
       "opencrypto-weight": 1
     },
-    "token_properties": {
-      "type": "object",
-      "title": "Token properties",
-      "description": "Properties of token. Valid only for tokens.",
-      "required": [
-        "platform"
-      ],
+    "contract_address": {
+      "title": "Contract address",
+      "description": "Contract address of the token.",
+      "type": "string",
       "opencrypto-weight": 1,
-      "opencrypto-weight-if": "root.type === 'token'",
-      "properties": {
-        "platform": {
-          "title": "Properties",
-          "description": "Blockchain where the asset is being run.",
-          "type": "string",
-          "opencrypto-weight": 1
-        },
-        "contract_address": {
-          "title": "Contract address",
-          "description": "Contract address of the token.",
-          "type": "string",
-          "opencrypto-weight": 1
-        },
-        "decimals": {
-          "title": "Decimals",
-          "description": "The number of digits that come after the decimal place when displaying token values on screen (format number).",
-          "type": "number",
-          "opencrypto-weight": 1
-        }
-      }
+      "opencrypto-weight-if": "root.type === 'token'"
     },
-    "forked": {
-      "type": "boolean",
-      "title": "Is forked",
-      "description": "Indicator if this asset was forked from another asset."
-    },
-    "fork_properties": {
-      "type": "object",
-      "title": "Fork properties",
-      "properties": {
-        "parent": {
-          "title": "Parent asset",
-          "description": "Asset from which was this asset forked.",
-          "type": "string"
-        },
-        "block": {
-          "title": "Block number",
-          "description": "Number of first block which differs from parent.",
-          "type": "number"
-        },
-        "time": {
-          "title": "Fork timestamp",
-          "description": "Date and time of first block.",
-          "type": "string",
-          "format": "date-time"
-        }
-      }
-    },
-    "networks": {
-      "type": "array",
-      "title": "Networks",
-      "items": {
-        "$schema": "http://json-schema.org/draft-06/schema#",
-        "$id": "https://schema.opencrypto.io/models/network#",
-        "title": "Network",
-        "description": "Ledger (blockchain) of digital asset.",
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "ID",
-            "description": "Unique identifier (to be written in small letters - for internal usage only).",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "description": "Name of the network (eg. Mainnet, Testnet, Rinkeby).",
-            "type": "string",
-            "opencrypto-weight": 1
-          },
-          "type": {
-            "title": "Type",
-            "description": "Type of Network (main, test).",
-            "type": "string",
-            "enum": [
-              "main",
-              "test"
-            ],
-            "opencrypto-weight": 1
-          },
-          "proof_type": {
-            "title": "Proof Type",
-            "description": "Proof type of the network (eg. PoW, PoS, Pow+PoS).",
-            "type": "string",
-            "opencrypto-weight": 1,
-            "opencrypto-weight-if": "root.type === 'main'"
-          },
-          "algorithm": {
-            "title": "Algorithm",
-            "description": "Algorithm that runs the network (eg. Sha-256, Cryptonight).",
-            "type": "string",
-            "opencrypto-weight": 1,
-            "opencrypto-weight-if": "root.type === 'main'"
-          },
-          "mineable": {
-            "title": "Mineable",
-            "description": "Mineable of the network (true / false)",
-            "type": "boolean",
-            "opencrypto-weight": 1,
-            "opencrypto-weight-if": "root.type === 'main'"
-          },
-          "target_block_time": {
-            "title": "Target block time",
-            "description": "Target block time in seconds (fromat number).",
-            "type": "number",
-            "opencrypto-weight": 1,
-            "opencrypto-weight-if": "root.type === 'main'"
-          },
-          "maximum_block_size": {
-            "title": "Maximum block size",
-            "description": "Maximum block size in bytes (format number).",
-            "type": "number",
-            "opencrypto-weight": 1,
-            "opencrypto-weight-if": "root.type === 'main'"
-          },
-          "start_date": {
-            "title": "Start date",
-            "description": "The date of start of network.",
-            "type": "string",
-            "format": "date",
-            "opencrypto-weight": 1
-          },
-          "web": {
-            "title": "Web links",
-            "description": "Webpages links.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "url"
-            }
-          },
-          "tools": {
-            "title": "Tools",
-            "description": "Tools for the asset network.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "type": {
-                  "title": "Type",
-                  "desctiption": "Type of the tool (explorer, faucet, other).",
-                  "type": "string",
-                  "enum": [
-                    "explorer",
-                    "faucet",
-                    "other"
-                  ]
-                },
-                "url": {
-                  "title": "URL",
-                  "description": "URL of the tool (format https://).",
-                  "type": "string",
-                  "format": "url"
-                }
-              }
-            }
-          },
-          "images": {
-            "title": "Images",
-            "desctiption": "Images of the logo.",
-            "type": "object",
-            "opencrypto-weight": 1,
-            "opencrypto-generated": true,
-            "properties": {
-              "logo_square": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string"
-                  },
-                  "data": {
-                    "type": "string",
-                    "media": {
-                      "binaryEncoding": "base64"
-                    }
-                  }
-                }
-              },
-              "logo_full": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string"
-                  },
-                  "data": {
-                    "type": "string",
-                    "media": {
-                      "binaryEncoding": "base64"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "webids": {
-            "title": "WebIDs",
-            "description": "Webs related to the project.",
-            "type": "object",
-            "opencrypto-validation": "webid",
-            "patternProperties": {
-              "^[a-z0-9-]{2,20}(\\/[a-z0-9-]{2,20})?$": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "opencrypto-weight": 1,
-      "opencrypto-weight-if": "root.type === 'blockchain'"
+    "decimals": {
+      "title": "Decimals",
+      "description": "The number of digits that come after the decimal place when displaying token values on screen (format number).",
+      "type": "number",
+      "opencrypto-weight": 1
     },
     "max_supply": {
       "title": "Max supply",
@@ -379,7 +183,7 @@
       }
     },
     "team": {
-      "title": "team",
+      "title": "Team Members",
       "description": "The team of the project.",
       "type": "array",
       "items": {

--- a/build/deref/client.json
+++ b/build/deref/client.json
@@ -10,6 +10,12 @@
       "title": "ID",
       "description": "Unique identifier of the digital asset client."
     },
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
+      "type": "string",
+      "opencrypto-generated": true
+    },
     "name": {
       "title": "Name",
       "type": "string",

--- a/build/deref/core.json
+++ b/build/deref/core.json
@@ -111,7 +111,7 @@
       }
     },
     "team": {
-      "title": "team",
+      "title": "Team Members",
       "description": "The team of the project.",
       "type": "array",
       "items": {

--- a/build/deref/exchange.json
+++ b/build/deref/exchange.json
@@ -13,19 +13,17 @@
       "description": "Unique identifier (to be written in small letters - for internal usage only).",
       "type": "string"
     },
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
+      "type": "string",
+      "opencrypto-generated": true
+    },
     "name": {
       "title": "Name",
       "description": "Name of the exchange.",
-      "type": "string"
-    },
-    "countries": {
-      "title": "Countries",
-      "description": "Country where the exchange is situated.",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "pattern": "^(\\w){2}$"
-      }
+      "type": "string",
+      "opencrypto-weight": 1
     },
     "web": {
       "title": "Web links",
@@ -35,6 +33,150 @@
         "type": "string",
         "format": "url"
       }
+    },
+    "countries": {
+      "title": "Countries",
+      "description": "Country where the exchange is situated.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^(\\w){2}$"
+      },
+      "opencrypto-weight": 1
+    },
+    "decentralized": {
+      "title": "Decentralized",
+      "type": "boolean",
+      "opencrypto-weight": 1
+    },
+    "user_security": {
+      "title": "User security",
+      "type": "object",
+      "properties": {
+        "two_factor": {
+          "title": "Two-factor authentication",
+          "type": "boolean"
+        },
+        "email_confirmation": {
+          "title": "Email confirmations",
+          "type": "boolean"
+        }
+      },
+      "opencrypto-weight": 1
+    },
+    "fees": {
+      "title": "Fees",
+      "type": "object",
+      "properties": {
+        "trading": {
+          "title": "Trading",
+          "type": "object",
+          "properties": {
+            "percentage": {
+              "title": "Percentage",
+              "type": "boolean"
+            },
+            "tier_based": {
+              "title": "Tier based",
+              "type": "boolean"
+            },
+            "taker": {
+              "title": "Taker",
+              "type": "number"
+            },
+            "maker": {
+              "title": "Maker",
+              "type": "number"
+            }
+          }
+        },
+        "funding": {
+          "title": "Funding",
+          "type": "object",
+          "properties": {
+            "percentage": {
+              "title": "Percentage",
+              "type": "boolean"
+            },
+            "tier_based": {
+              "title": "Tier based",
+              "type": "boolean"
+            },
+            "withdraw": {
+              "title": "Withdrawal Fee",
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {
+                  "type": "number"
+                }
+              }
+            },
+            "withdraw_minimum": {
+              "title": "Minimum Withdrawal",
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {
+                  "type": "number"
+                }
+              }
+            },
+            "deposit": {
+              "title": "Deposit",
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "apps": {
+      "title": "Applications",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "platform": {
+            "title": "Platform",
+            "type": "string",
+            "enum": [
+              "android",
+              "ios",
+              "macos",
+              "linux"
+            ],
+            "opencrypto-weight": 1
+          },
+          "web": {
+            "title": "Web",
+            "type": "string",
+            "format": "url",
+            "opencrypto-weight": 1
+          },
+          "market_id": {
+            "title": "Market ID",
+            "type": "string",
+            "opencrypto-weight": 1
+          },
+          "download_url": {
+            "title": "Download URL",
+            "description": "URL for download. Fill only if market_id is not available.",
+            "type": "string",
+            "format": "url",
+            "opencrypto-weight": 1,
+            "opencrypto-weight-if": "!root.market_id"
+          }
+        }
+      },
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
     },
     "api": {
       "url": {
@@ -85,9 +227,79 @@
       }
     },
     "markets": {
+      "title": "Markets",
       "type": "array",
       "items": {
         "$ref": "opencrypto:market#"
+      },
+      "opencrypto-weight": 1
+    },
+    "history": {
+      "title": "History",
+      "description": "History of the project, important events, happenings, facts.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "title": "Date",
+            "description": "The date of the event (format YYYY/MM/DD).",
+            "type": "string",
+            "format": "date",
+            "opencrypto-weight": 1
+          },
+          "title": {
+            "title": "Title",
+            "description": "Title of the event.",
+            "type": "string",
+            "opencrypto-weight": 1
+          },
+          "description": {
+            "title": "Description",
+            "description": "The short description of the event.",
+            "type": "string",
+            "opencrypto-weight": 0.5
+          },
+          "url": {
+            "title": "URL",
+            "description": "URL of the link with event information (format https://).",
+            "type": "string",
+            "format": "url",
+            "opencrypto-weight": 0.5
+          }
+        }
+      }
+    },
+    "webids": {
+      "title": "WebIDs",
+      "description": "Webs related to the project.",
+      "type": "object",
+      "opencrypto-validation": "webid",
+      "patternProperties": {
+        "^[a-z0-9-]{2,20}(\\/[a-z0-9-]{2,20})?$": {
+          "type": "string"
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources",
+      "description": "Resources where other information about the project could be found.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "title": "Title",
+            "description": "Name of the resources.",
+            "type": "string"
+          },
+          "url": {
+            "title": "URL",
+            "description": "URL of the resources (format https://).",
+            "type": "string",
+            "format": "url"
+          }
+        }
       }
     }
   }

--- a/build/deref/ledger.json
+++ b/build/deref/ledger.json
@@ -1,0 +1,356 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://schema.opencrypto.io/models/ledger#",
+  "title": "Ledger",
+  "description": "Ledger - blockchain or sidechain.",
+  "type": "object",
+  "required": [
+    "name",
+    "type"
+  ],
+  "properties": {
+    "id": {
+      "title": "ID",
+      "description": "Unique identifier (to be written in small letters - for internal usage only).",
+      "type": "string"
+    },
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
+      "type": "string",
+      "opencrypto-generated": true
+    },
+    "name": {
+      "title": "Name",
+      "description": "The official name of the ledger.",
+      "type": "string",
+      "opencrypto-weight": 1
+    },
+    "type": {
+      "title": "Type",
+      "type": "string",
+      "enum": [
+        "blockchain",
+        "sidechain",
+        "payment-channels"
+      ]
+    },
+    "forked": {
+      "type": "boolean",
+      "title": "Is forked",
+      "description": "Indicator if this asset was forked from another asset."
+    },
+    "fork_properties": {
+      "type": "object",
+      "title": "Fork properties",
+      "properties": {
+        "parent": {
+          "title": "Parent asset",
+          "description": "Asset from which was this asset forked.",
+          "type": "string"
+        },
+        "block": {
+          "title": "Block number",
+          "description": "Number of first block which differs from parent.",
+          "type": "number"
+        },
+        "time": {
+          "title": "Fork timestamp",
+          "description": "Date and time of first block.",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "web": {
+      "title": "Web links",
+      "description": "Webpages links.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "url"
+      }
+    },
+    "start_date": {
+      "title": "Start Date",
+      "description": "The day when the assets began to be first activated (format YYYY/MM/DD).",
+      "type": "string",
+      "format": "date",
+      "opencrypto-weight": 1
+    },
+    "networks": {
+      "type": "array",
+      "title": "Networks",
+      "items": {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "$id": "https://schema.opencrypto.io/models/network#",
+        "title": "Network",
+        "description": "Ledger (blockchain) of digital asset.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "ID",
+            "description": "Unique identifier (to be written in small letters - for internal usage only).",
+            "type": "string"
+          },
+          "pid": {
+            "title": "PID",
+            "description": "Project ID (generated).",
+            "type": "string",
+            "opencrypto-generated": true
+          },
+          "name": {
+            "title": "Name",
+            "description": "Name of the network (eg. Mainnet, Testnet, Rinkeby).",
+            "type": "string",
+            "opencrypto-weight": 1
+          },
+          "type": {
+            "title": "Type",
+            "description": "Type of Network (main, test).",
+            "type": "string",
+            "enum": [
+              "main",
+              "test"
+            ],
+            "opencrypto-weight": 1
+          },
+          "proof_type": {
+            "title": "Proof Type",
+            "description": "Proof type of the network (eg. PoW, PoS, Pow+PoS).",
+            "type": "string",
+            "opencrypto-weight": 1,
+            "opencrypto-weight-if": "root.type === 'main'"
+          },
+          "algorithm": {
+            "title": "Algorithm",
+            "description": "Algorithm that runs the network (eg. Sha-256, Cryptonight).",
+            "type": "string",
+            "opencrypto-weight": 1,
+            "opencrypto-weight-if": "root.type === 'main'"
+          },
+          "mineable": {
+            "title": "Mineable",
+            "description": "Mineable of the network (true / false)",
+            "type": "boolean",
+            "opencrypto-weight": 1,
+            "opencrypto-weight-if": "root.type === 'main'"
+          },
+          "target_block_time": {
+            "title": "Target block time",
+            "description": "Target block time in seconds (fromat number).",
+            "type": "number",
+            "opencrypto-weight": 1,
+            "opencrypto-weight-if": "root.type === 'main'"
+          },
+          "maximum_block_size": {
+            "title": "Maximum block size",
+            "description": "Maximum block size in bytes (format number).",
+            "type": "number",
+            "opencrypto-weight": 1,
+            "opencrypto-weight-if": "root.type === 'main'"
+          },
+          "start_date": {
+            "title": "Start date",
+            "description": "The date of start of network.",
+            "type": "string",
+            "format": "date",
+            "opencrypto-weight": 1
+          },
+          "web": {
+            "title": "Web links",
+            "description": "Webpages links.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "url"
+            }
+          },
+          "tools": {
+            "title": "Tools",
+            "description": "Tools for the asset network.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "type": {
+                  "title": "Type",
+                  "desctiption": "Type of the tool (explorer, faucet, other).",
+                  "type": "string",
+                  "enum": [
+                    "explorer",
+                    "faucet",
+                    "other"
+                  ]
+                },
+                "url": {
+                  "title": "URL",
+                  "description": "URL of the tool (format https://).",
+                  "type": "string",
+                  "format": "url"
+                }
+              }
+            }
+          },
+          "images": {
+            "title": "Images",
+            "desctiption": "Images of the logo.",
+            "type": "object",
+            "opencrypto-weight": 1,
+            "opencrypto-generated": true,
+            "properties": {
+              "logo_square": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "string",
+                    "media": {
+                      "binaryEncoding": "base64"
+                    }
+                  }
+                }
+              },
+              "logo_full": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "string",
+                    "media": {
+                      "binaryEncoding": "base64"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "webids": {
+            "title": "WebIDs",
+            "description": "Webs related to the project.",
+            "type": "object",
+            "opencrypto-validation": "webid",
+            "patternProperties": {
+              "^[a-z0-9-]{2,20}(\\/[a-z0-9-]{2,20})?$": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "opencrypto-weight": 1
+    },
+    "history": {
+      "title": "History",
+      "description": "History of the project, important events, happenings, facts.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "title": "Date",
+            "description": "The date of the event (format YYYY/MM/DD).",
+            "type": "string",
+            "format": "date",
+            "opencrypto-weight": 1
+          },
+          "title": {
+            "title": "Title",
+            "description": "Title of the event.",
+            "type": "string",
+            "opencrypto-weight": 1
+          },
+          "description": {
+            "title": "Description",
+            "description": "The short description of the event.",
+            "type": "string",
+            "opencrypto-weight": 0.5
+          },
+          "url": {
+            "title": "URL",
+            "description": "URL of the link with event information (format https://).",
+            "type": "string",
+            "format": "url",
+            "opencrypto-weight": 0.5
+          }
+        }
+      }
+    },
+    "images": {
+      "title": "Images",
+      "desctiption": "Images of the logo.",
+      "type": "object",
+      "opencrypto-weight": 1,
+      "opencrypto-generated": true,
+      "properties": {
+        "logo_square": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "string",
+              "media": {
+                "binaryEncoding": "base64"
+              }
+            }
+          }
+        },
+        "logo_full": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "string",
+              "media": {
+                "binaryEncoding": "base64"
+              }
+            }
+          }
+        }
+      }
+    },
+    "webids": {
+      "title": "WebIDs",
+      "description": "Webs related to the project.",
+      "type": "object",
+      "opencrypto-validation": "webid",
+      "patternProperties": {
+        "^[a-z0-9-]{2,20}(\\/[a-z0-9-]{2,20})?$": {
+          "type": "string"
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources",
+      "description": "Resources where other information about the project could be found.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "title": "Title",
+            "description": "Name of the resources.",
+            "type": "string"
+          },
+          "url": {
+            "title": "URL",
+            "description": "URL of the resources (format https://).",
+            "type": "string",
+            "format": "url"
+          }
+        }
+      }
+    }
+  }
+}

--- a/build/deref/network.json
+++ b/build/deref/network.json
@@ -10,6 +10,12 @@
       "description": "Unique identifier (to be written in small letters - for internal usage only).",
       "type": "string"
     },
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
+      "type": "string",
+      "opencrypto-generated": true
+    },
     "name": {
       "title": "Name",
       "description": "Name of the network (eg. Mainnet, Testnet, Rinkeby).",

--- a/build/deref/project.json
+++ b/build/deref/project.json
@@ -36,13 +36,14 @@
         "format": "url"
       }
     },
-    "assets": {
+    "ledgers": {
+      "title": "Ledgers",
       "type": "array",
       "items": {
         "$schema": "http://json-schema.org/draft-06/schema#",
-        "$id": "https://schema.opencrypto.io/models/asset#",
-        "title": "Asset",
-        "description": "Cryptocurrency - digital asset (blockchain or token).",
+        "$id": "https://schema.opencrypto.io/models/ledger#",
+        "title": "Ledger",
+        "description": "Ledger - blockchain or sidechain.",
         "type": "object",
         "required": [
           "name",
@@ -54,57 +55,26 @@
             "description": "Unique identifier (to be written in small letters - for internal usage only).",
             "type": "string"
           },
-          "type": {
-            "title": "Type",
-            "description": "Type of asset, eq. blockchain or token.",
+          "pid": {
+            "title": "PID",
+            "description": "Project ID (generated).",
             "type": "string",
-            "enum": [
-              "blockchain",
-              "token"
-            ],
-            "opencrypto-weight": 1
+            "opencrypto-generated": true
           },
           "name": {
             "title": "Name",
-            "description": "The official name of the asset.",
+            "description": "The official name of the ledger.",
             "type": "string",
             "opencrypto-weight": 1
           },
-          "symbol": {
-            "title": "Symbol",
-            "description": "One to nine characters (to be written in capital letters).",
+          "type": {
+            "title": "Type",
             "type": "string",
-            "opencrypto-weight": 1
-          },
-          "token_properties": {
-            "type": "object",
-            "title": "Token properties",
-            "description": "Properties of token. Valid only for tokens.",
-            "required": [
-              "platform"
-            ],
-            "opencrypto-weight": 1,
-            "opencrypto-weight-if": "root.type === 'token'",
-            "properties": {
-              "platform": {
-                "title": "Properties",
-                "description": "Blockchain where the asset is being run.",
-                "type": "string",
-                "opencrypto-weight": 1
-              },
-              "contract_address": {
-                "title": "Contract address",
-                "description": "Contract address of the token.",
-                "type": "string",
-                "opencrypto-weight": 1
-              },
-              "decimals": {
-                "title": "Decimals",
-                "description": "The number of digits that come after the decimal place when displaying token values on screen (format number).",
-                "type": "number",
-                "opencrypto-weight": 1
-              }
-            }
+            "enum": [
+              "blockchain",
+              "sidechain",
+              "payment-channels"
+            ]
           },
           "forked": {
             "type": "boolean",
@@ -133,6 +103,22 @@
               }
             }
           },
+          "web": {
+            "title": "Web links",
+            "description": "Webpages links.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "url"
+            }
+          },
+          "start_date": {
+            "title": "Start Date",
+            "description": "The day when the assets began to be first activated (format YYYY/MM/DD).",
+            "type": "string",
+            "format": "date",
+            "opencrypto-weight": 1
+          },
           "networks": {
             "type": "array",
             "title": "Networks",
@@ -147,6 +133,12 @@
                   "title": "ID",
                   "description": "Unique identifier (to be written in small letters - for internal usage only).",
                   "type": "string"
+                },
+                "pid": {
+                  "title": "PID",
+                  "description": "Project ID (generated).",
+                  "type": "string",
+                  "opencrypto-generated": true
                 },
                 "name": {
                   "title": "Name",
@@ -294,8 +286,183 @@
                 }
               }
             },
+            "opencrypto-weight": 1
+          },
+          "history": {
+            "title": "History",
+            "description": "History of the project, important events, happenings, facts.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "date": {
+                  "title": "Date",
+                  "description": "The date of the event (format YYYY/MM/DD).",
+                  "type": "string",
+                  "format": "date",
+                  "opencrypto-weight": 1
+                },
+                "title": {
+                  "title": "Title",
+                  "description": "Title of the event.",
+                  "type": "string",
+                  "opencrypto-weight": 1
+                },
+                "description": {
+                  "title": "Description",
+                  "description": "The short description of the event.",
+                  "type": "string",
+                  "opencrypto-weight": 0.5
+                },
+                "url": {
+                  "title": "URL",
+                  "description": "URL of the link with event information (format https://).",
+                  "type": "string",
+                  "format": "url",
+                  "opencrypto-weight": 0.5
+                }
+              }
+            }
+          },
+          "images": {
+            "title": "Images",
+            "desctiption": "Images of the logo.",
+            "type": "object",
             "opencrypto-weight": 1,
-            "opencrypto-weight-if": "root.type === 'blockchain'"
+            "opencrypto-generated": true,
+            "properties": {
+              "logo_square": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "string",
+                    "media": {
+                      "binaryEncoding": "base64"
+                    }
+                  }
+                }
+              },
+              "logo_full": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "string",
+                    "media": {
+                      "binaryEncoding": "base64"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "webids": {
+            "title": "WebIDs",
+            "description": "Webs related to the project.",
+            "type": "object",
+            "opencrypto-validation": "webid",
+            "patternProperties": {
+              "^[a-z0-9-]{2,20}(\\/[a-z0-9-]{2,20})?$": {
+                "type": "string"
+              }
+            }
+          },
+          "resources": {
+            "title": "Resources",
+            "description": "Resources where other information about the project could be found.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "title": "Title",
+                  "description": "Name of the resources.",
+                  "type": "string"
+                },
+                "url": {
+                  "title": "URL",
+                  "description": "URL of the resources (format https://).",
+                  "type": "string",
+                  "format": "url"
+                }
+              }
+            }
+          }
+        }
+      },
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
+    },
+    "assets": {
+      "title": "Assets",
+      "type": "array",
+      "items": {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "$id": "https://schema.opencrypto.io/models/asset#",
+        "title": "Asset",
+        "description": "Cryptocurrency - digital asset (native or token).",
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "ledger"
+        ],
+        "properties": {
+          "id": {
+            "title": "ID",
+            "description": "Unique identifier (to be written in small letters - for internal usage only).",
+            "type": "string"
+          },
+          "pid": {
+            "title": "PID",
+            "description": "Project ID (generated).",
+            "type": "string",
+            "opencrypto-generated": true
+          },
+          "name": {
+            "title": "Name",
+            "description": "The official name of the asset.",
+            "type": "string",
+            "opencrypto-weight": 1
+          },
+          "type": {
+            "title": "Type",
+            "description": "Type of asset, eq. native or token.",
+            "type": "string",
+            "enum": [
+              "native",
+              "token"
+            ],
+            "opencrypto-weight": 1
+          },
+          "ledger": {
+            "title": "Ledger",
+            "description": "Ledger where the asset is being run.",
+            "type": "string"
+          },
+          "symbol": {
+            "title": "Symbol",
+            "description": "One to nine characters (to be written in capital letters).",
+            "type": "string",
+            "opencrypto-weight": 1
+          },
+          "contract_address": {
+            "title": "Contract address",
+            "description": "Contract address of the token.",
+            "type": "string",
+            "opencrypto-weight": 1,
+            "opencrypto-weight-if": "root.type === 'token'"
+          },
+          "decimals": {
+            "title": "Decimals",
+            "description": "The number of digits that come after the decimal place when displaying token values on screen (format number).",
+            "type": "number",
+            "opencrypto-weight": 1
           },
           "max_supply": {
             "title": "Max supply",
@@ -419,7 +586,7 @@
             }
           },
           "team": {
-            "title": "team",
+            "title": "Team Members",
             "description": "The team of the project.",
             "type": "array",
             "items": {
@@ -700,9 +867,11 @@
           }
         }
       },
-      "opencrypto-weight": 1
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
     },
     "exchanges": {
+      "title": "Exchanges",
       "type": "array",
       "items": {
         "$schema": "http://json-schema.org/draft-06/schema#",
@@ -719,19 +888,17 @@
             "description": "Unique identifier (to be written in small letters - for internal usage only).",
             "type": "string"
           },
+          "pid": {
+            "title": "PID",
+            "description": "Project ID (generated).",
+            "type": "string",
+            "opencrypto-generated": true
+          },
           "name": {
             "title": "Name",
             "description": "Name of the exchange.",
-            "type": "string"
-          },
-          "countries": {
-            "title": "Countries",
-            "description": "Country where the exchange is situated.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "pattern": "^(\\w){2}$"
-            }
+            "type": "string",
+            "opencrypto-weight": 1
           },
           "web": {
             "title": "Web links",
@@ -741,6 +908,150 @@
               "type": "string",
               "format": "url"
             }
+          },
+          "countries": {
+            "title": "Countries",
+            "description": "Country where the exchange is situated.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^(\\w){2}$"
+            },
+            "opencrypto-weight": 1
+          },
+          "decentralized": {
+            "title": "Decentralized",
+            "type": "boolean",
+            "opencrypto-weight": 1
+          },
+          "user_security": {
+            "title": "User security",
+            "type": "object",
+            "properties": {
+              "two_factor": {
+                "title": "Two-factor authentication",
+                "type": "boolean"
+              },
+              "email_confirmation": {
+                "title": "Email confirmations",
+                "type": "boolean"
+              }
+            },
+            "opencrypto-weight": 1
+          },
+          "fees": {
+            "title": "Fees",
+            "type": "object",
+            "properties": {
+              "trading": {
+                "title": "Trading",
+                "type": "object",
+                "properties": {
+                  "percentage": {
+                    "title": "Percentage",
+                    "type": "boolean"
+                  },
+                  "tier_based": {
+                    "title": "Tier based",
+                    "type": "boolean"
+                  },
+                  "taker": {
+                    "title": "Taker",
+                    "type": "number"
+                  },
+                  "maker": {
+                    "title": "Maker",
+                    "type": "number"
+                  }
+                }
+              },
+              "funding": {
+                "title": "Funding",
+                "type": "object",
+                "properties": {
+                  "percentage": {
+                    "title": "Percentage",
+                    "type": "boolean"
+                  },
+                  "tier_based": {
+                    "title": "Tier based",
+                    "type": "boolean"
+                  },
+                  "withdraw": {
+                    "title": "Withdrawal Fee",
+                    "type": "object",
+                    "patternProperties": {
+                      "^.+$": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "withdraw_minimum": {
+                    "title": "Minimum Withdrawal",
+                    "type": "object",
+                    "patternProperties": {
+                      "^.+$": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "deposit": {
+                    "title": "Deposit",
+                    "type": "object",
+                    "patternProperties": {
+                      "^.+$": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "apps": {
+            "title": "Applications",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "title": "Name",
+                  "type": "string"
+                },
+                "platform": {
+                  "title": "Platform",
+                  "type": "string",
+                  "enum": [
+                    "android",
+                    "ios",
+                    "macos",
+                    "linux"
+                  ],
+                  "opencrypto-weight": 1
+                },
+                "web": {
+                  "title": "Web",
+                  "type": "string",
+                  "format": "url",
+                  "opencrypto-weight": 1
+                },
+                "market_id": {
+                  "title": "Market ID",
+                  "type": "string",
+                  "opencrypto-weight": 1
+                },
+                "download_url": {
+                  "title": "Download URL",
+                  "description": "URL for download. Fill only if market_id is not available.",
+                  "type": "string",
+                  "format": "url",
+                  "opencrypto-weight": 1,
+                  "opencrypto-weight-if": "!root.market_id"
+                }
+              }
+            },
+            "opencrypto-weight": 1,
+            "opencrypto-weight-min": 0
           },
           "api": {
             "url": {
@@ -791,15 +1102,88 @@
             }
           },
           "markets": {
+            "title": "Markets",
             "type": "array",
             "items": {
               "$ref": "opencrypto:market#"
+            },
+            "opencrypto-weight": 1
+          },
+          "history": {
+            "title": "History",
+            "description": "History of the project, important events, happenings, facts.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "date": {
+                  "title": "Date",
+                  "description": "The date of the event (format YYYY/MM/DD).",
+                  "type": "string",
+                  "format": "date",
+                  "opencrypto-weight": 1
+                },
+                "title": {
+                  "title": "Title",
+                  "description": "Title of the event.",
+                  "type": "string",
+                  "opencrypto-weight": 1
+                },
+                "description": {
+                  "title": "Description",
+                  "description": "The short description of the event.",
+                  "type": "string",
+                  "opencrypto-weight": 0.5
+                },
+                "url": {
+                  "title": "URL",
+                  "description": "URL of the link with event information (format https://).",
+                  "type": "string",
+                  "format": "url",
+                  "opencrypto-weight": 0.5
+                }
+              }
+            }
+          },
+          "webids": {
+            "title": "WebIDs",
+            "description": "Webs related to the project.",
+            "type": "object",
+            "opencrypto-validation": "webid",
+            "patternProperties": {
+              "^[a-z0-9-]{2,20}(\\/[a-z0-9-]{2,20})?$": {
+                "type": "string"
+              }
+            }
+          },
+          "resources": {
+            "title": "Resources",
+            "description": "Resources where other information about the project could be found.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "title": "Title",
+                  "description": "Name of the resources.",
+                  "type": "string"
+                },
+                "url": {
+                  "title": "URL",
+                  "description": "URL of the resources (format https://).",
+                  "type": "string",
+                  "format": "url"
+                }
+              }
             }
           }
         }
-      }
+      },
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
     },
     "clients": {
+      "title": "Clients",
       "type": "array",
       "items": {
         "$schema": "http://json-schema.org/draft-06/schema#",
@@ -813,16 +1197,24 @@
             "title": "ID",
             "description": "Unique identifier of the digital asset client."
           },
+          "pid": {
+            "title": "PID",
+            "description": "Project ID (generated).",
+            "type": "string",
+            "opencrypto-generated": true
+          },
           "name": {
             "title": "Name",
             "type": "string",
             "description": "Name of client."
           }
         }
-      }
+      },
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
     },
     "team": {
-      "title": "team",
+      "title": "Team Members",
       "description": "The team of the project.",
       "type": "array",
       "items": {
@@ -864,9 +1256,9 @@
       "opencrypto-weight": 1
     },
     "team_url": {
+      "title": "Team URL",
       "type": "string",
-      "format": "url",
-      "opencrypto-weight": 0.5
+      "format": "url"
     },
     "contacts": {
       "title": "Contacts",

--- a/examples/models/asset.json
+++ b/examples/models/asset.json
@@ -2,34 +2,8 @@
   "id": "btc",
   "symbol": "BTC",
   "name": "Bitcoin",
-  "type": "blockchain",
-  "networks": [
-    {
-      "id": "main",
-      "type": "main",
-      "name": "mainnet",
-      "proof_type": "PoW",
-      "algorithm": "SHA256",
-      "mineable": true,
-      "maximum_block_size": 8388608,
-      "target_block_time": 15,
-      "tools": [
-        {
-          "type": "explorer",
-          "url": "https://www.blockchain.com/explorer"
-        },
-        {
-          "type": "explorer",
-          "url": "https://live.blockcypher.com/btc/"
-        }
-      ]
-    },
-    {
-      "id": "test",
-      "type": "test",
-      "name": "testnet"
-    }
-  ],
+  "type": "native",
+  "ledger": "bitcoin",
   "max_supply": 21000000,
   "first_distribution": [
     {

--- a/examples/models/exchange.json
+++ b/examples/models/exchange.json
@@ -11,5 +11,27 @@
     {
       "id": "bitfinex-eth-usd"
     }
-  ]
+  ],
+  "decentralized": false,
+  "user_security": {
+    "two_factor": true,
+    "email_confirmation": true
+  },
+  "apps": [
+    {
+      "name": "Bitfinex iOS app",
+      "web": "https://www.bitfinex.com/app",
+      "market_id": "id1079033582",
+      "platform": "ios"
+    },
+    {
+      "name": "Bitfinex Android app",
+      "web": "https://www.bitfinex.com/app",
+      "market_id": "com.bitfinex.bfxapp",
+      "platform": "android"
+    }
+  ],
+  "webids": {
+    "twitter": "bitfinex"
+  }
 }

--- a/examples/models/ledger.json
+++ b/examples/models/ledger.json
@@ -1,0 +1,33 @@
+{
+  "id": "btc",
+  "symbol": "BTC",
+  "name": "Bitcoin",
+  "type": "blockchain",
+  "networks": [
+    {
+      "id": "main",
+      "type": "main",
+      "name": "mainnet",
+      "proof_type": "PoW",
+      "algorithm": "SHA256",
+      "mineable": true,
+      "maximum_block_size": 8388608,
+      "target_block_time": 15,
+      "tools": [
+        {
+          "type": "explorer",
+          "url": "https://www.blockchain.com/explorer"
+        },
+        {
+          "type": "explorer",
+          "url": "https://live.blockcypher.com/btc/"
+        }
+      ]
+    },
+    {
+      "id": "test",
+      "type": "test",
+      "name": "testnet"
+    }
+  ]
+}

--- a/examples/models/project.json
+++ b/examples/models/project.json
@@ -5,7 +5,7 @@
   "web": [
     "https://bitcoin.org/"
   ],
-  "assets": [
+  "ledgers": [
     {
       "id": "btc",
       "symbol": "BTC",
@@ -37,7 +37,28 @@
           "type": "test",
           "name": "testnet"
         }
-      ],
+      ]
+    },
+    {
+      "id": "ethereum-classic",
+      "name": "Ethereum Classic",
+      "symbol": "ETC",
+      "type": "blockchain",
+      "forked": true,
+      "fork_properties": {
+        "parent": "ethereum",
+        "block": 1920000,
+        "time": "2016-07-20T13:20:39Z"
+      }
+    }
+  ],
+  "assets": [
+    {
+      "id": "btc",
+      "symbol": "BTC",
+      "name": "Bitcoin",
+      "type": "native",
+      "ledger": "bitcoin",
       "max_supply": 21000000,
       "first_distribution": [
         {
@@ -73,23 +94,9 @@
       "name": "Bitcoin Gas",
       "symbol": "BGAS",
       "type": "token",
-      "token_properties": {
-        "platform": "ethereum",
-        "contract_address": "0x00000000..",
-        "decimals": 18
-      }
-    },
-    {
-      "id": "ethereum-classic",
-      "name": "Ethereum Classic",
-      "symbol": "ETC",
-      "type": "blockchain",
-      "forked": true,
-      "fork_properties": {
-        "parent": "ethereum",
-        "block": 1920000,
-        "time": "2016-07-20T13:20:39Z"
-      }
+      "ledger": "ethereum",
+      "contract_address": "0x00000000..",
+      "decimals": 18
     }
   ],
   "team": [

--- a/models/asset.json
+++ b/models/asset.json
@@ -2,11 +2,12 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://schema.opencrypto.io/models/asset#",
   "title": "Asset",
-  "description": "Cryptocurrency - digital asset (blockchain or token).",
+  "description": "Cryptocurrency - digital asset (native or token).",
   "type": "object",
   "required": [
     "name",
-    "type"
+    "type",
+    "ledger"
   ],
   "properties": {
     "id": {
@@ -14,15 +15,11 @@
       "description": "Unique identifier (to be written in small letters - for internal usage only).",
       "type": "string"
     },
-    "type": {
-      "title": "Type",
-      "description": "Type of asset, eq. blockchain or token.",
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
       "type": "string",
-      "enum": [
-        "blockchain",
-        "token"
-      ],
-      "opencrypto-weight": 1
+      "opencrypto-generated": true
     },
     "name": {
       "title": "Name",
@@ -30,77 +27,39 @@
       "type": "string",
       "opencrypto-weight": 1
     },
+    "type": {
+      "title": "Type",
+      "description": "Type of asset, eq. native or token.",
+      "type": "string",
+      "enum": [
+        "native",
+        "token"
+      ],
+      "opencrypto-weight": 1
+    },
+    "ledger": {
+      "title": "Ledger",
+      "description": "Ledger where the asset is being run.",
+      "type": "string"
+    },
     "symbol": {
       "title": "Symbol",
       "description": "One to nine characters (to be written in capital letters).",
       "type": "string",
       "opencrypto-weight": 1
     },
-    "token_properties": {
-      "type": "object",
-      "title": "Token properties",
-      "description": "Properties of token. Valid only for tokens.",
-      "required": [
-        "platform"
-      ],
+    "contract_address": {
+      "title": "Contract address",
+      "description": "Contract address of the token.",
+      "type": "string",
       "opencrypto-weight": 1,
-      "opencrypto-weight-if": "root.type === 'token'",
-      "properties": {
-        "platform": {
-          "title": "Properties",
-          "description": "Blockchain where the asset is being run.",
-          "type": "string",
-          "opencrypto-weight": 1
-        },
-        "contract_address": {
-          "title": "Contract address",
-          "description": "Contract address of the token.",
-          "type": "string",
-          "opencrypto-weight": 1
-        },
-        "decimals": {
-          "title": "Decimals",
-          "description": "The number of digits that come after the decimal place when displaying token values on screen (format number).",
-          "type": "number",
-          "opencrypto-weight": 1
-        }
-      }
+      "opencrypto-weight-if": "root.type === 'token'"
     },
-    "forked": {
-      "type": "boolean",
-      "title": "Is forked",
-      "description": "Indicator if this asset was forked from another asset."
-    },
-    "fork_properties": {
-      "type": "object",
-      "title": "Fork properties",
-      "properties": {
-        "parent": {
-          "title": "Parent asset",
-          "description": "Asset from which was this asset forked.",
-          "type": "string"
-        },
-        "block": {
-          "title": "Block number",
-          "description": "Number of first block which differs from parent.",
-          "type": "number"
-        },
-        "time": {
-          "title": "Fork timestamp",
-          "description": "Date and time of first block.",
-          "type": "string",
-          "format": "date-time"
-        }
-      }
-    },
-    "networks": {
-      "type": "array",
-      "title": "Networks",
-      "items": {
-        "$ref": "https://schema.opencrypto.io/models/network#/"
-      },
-      "opencrypto-weight": 1,
-      "opencrypto-weight-if": "root.type === 'blockchain'"
+    "decimals": {
+      "title": "Decimals",
+      "description": "The number of digits that come after the decimal place when displaying token values on screen (format number).",
+      "type": "number",
+      "opencrypto-weight": 1
     },
     "max_supply": {
       "title": "Max supply",

--- a/models/client.json
+++ b/models/client.json
@@ -10,6 +10,12 @@
       "title": "ID",
       "description": "Unique identifier of the digital asset client."
     },
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
+      "type": "string",
+      "opencrypto-generated": true
+    },
     "name": {
       "title": "Name",
       "type": "string",

--- a/models/core.json
+++ b/models/core.json
@@ -90,7 +90,7 @@
       }
     },
     "team": {
-      "title": "team",
+      "title": "Team Members",
       "description": "The team of the project.",
       "type": "array",
       "items": {

--- a/models/exchange.json
+++ b/models/exchange.json
@@ -13,10 +13,21 @@
       "description": "Unique identifier (to be written in small letters - for internal usage only).",
       "type": "string"
     },
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
+      "type": "string",
+      "opencrypto-generated": true
+    },
     "name": {
       "title": "Name",
       "description": "Name of the exchange.",
-      "type": "string"
+      "type": "string",
+      "opencrypto-weight": 1
+    },
+    "web": {
+      "$ref": "https://schema.opencrypto.io/models/core#/definitions/links",
+      "opencrypto-weight": 1
     },
     "countries": {
       "title": "Countries",
@@ -25,10 +36,142 @@
       "items": {
         "type": "string",
         "pattern": "^(\\w){2}$"
+      },
+      "opencrypto-weight": 1
+    },
+    "decentralized": {
+      "title": "Decentralized",
+      "type": "boolean",
+      "opencrypto-weight": 1
+    },
+    "user_security": {
+      "title": "User security",
+      "type": "object",
+      "properties": {
+        "two_factor": {
+          "title": "Two-factor authentication",
+          "type": "boolean"
+        },
+        "email_confirmation": {
+          "title": "Email confirmations",
+          "type": "boolean"
+        }
+      },
+      "opencrypto-weight": 1
+    },
+    "fees": {
+      "title": "Fees",
+      "type": "object",
+      "properties": {
+        "trading": {
+          "title": "Trading",
+          "type": "object",
+          "properties": {
+            "percentage": {
+              "title": "Percentage",
+              "type": "boolean"
+            },
+            "tier_based": {
+              "title": "Tier based",
+              "type": "boolean"
+            },
+            "taker": {
+              "title": "Taker",
+              "type": "number"
+            },
+            "maker": {
+              "title": "Maker",
+              "type": "number"
+            }
+          }
+        },
+        "funding": {
+          "title": "Funding",
+          "type": "object",
+          "properties": {
+            "percentage": {
+              "title": "Percentage",
+              "type": "boolean"
+            },
+            "tier_based": {
+              "title": "Tier based",
+              "type": "boolean"
+            },
+            "withdraw": {
+              "title": "Withdrawal Fee",
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {
+                  "type": "number"
+                }
+              }
+            },
+            "withdraw_minimum": {
+              "title": "Minimum Withdrawal",
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {
+                  "type": "number"
+                }
+              }
+            },
+            "deposit": {
+              "title": "Deposit",
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
       }
     },
-    "web": {
-      "$ref": "https://schema.opencrypto.io/models/core#/definitions/links"
+    "apps": {
+      "title": "Applications",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "platform": {
+            "title": "Platform",
+            "type": "string",
+            "enum": [
+              "android",
+              "ios",
+              "macos",
+              "linux"
+            ],
+            "opencrypto-weight": 1
+          },
+          "web": {
+            "title": "Web",
+            "type": "string",
+            "format": "url",
+            "opencrypto-weight": 1
+          },
+          "market_id": {
+            "title": "Market ID",
+            "type": "string",
+            "opencrypto-weight": 1
+          },
+          "download_url": {
+            "title": "Download URL",
+            "description": "URL for download. Fill only if market_id is not available.",
+            "type": "string",
+            "format": "url",
+            "opencrypto-weight": 1,
+            "opencrypto-weight-if": "!root.market_id"
+          }
+        }
+      },
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
     },
     "api": {
       "url": {
@@ -39,10 +182,21 @@
       "$ref": "https://schema.opencrypto.io/models/core#/definitions/images"
     },
     "markets": {
+      "title": "Markets",
       "type": "array",
       "items": {
         "$ref": "https://schema.opencrypto.io/models/market#"
-      }
+      },
+      "opencrypto-weight": 1
+    },
+    "history": {
+      "$ref": "https://schema.opencrypto.io/models/core#/definitions/history"
+    },
+    "webids": {
+      "$ref": "https://schema.opencrypto.io/models/core#/definitions/webids"
+    },
+    "resources": {
+      "$ref": "https://schema.opencrypto.io/models/core#/definitions/resources"
     }
   }
 }

--- a/models/ledger.json
+++ b/models/ledger.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://schema.opencrypto.io/models/ledger#",
+  "title": "Ledger",
+  "description": "Ledger - blockchain or sidechain.",
+  "type": "object",
+  "required": [
+    "name",
+    "type"
+  ],
+  "properties": {
+    "id": {
+      "title": "ID",
+      "description": "Unique identifier (to be written in small letters - for internal usage only).",
+      "type": "string"
+    },
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
+      "type": "string",
+      "opencrypto-generated": true
+    },
+    "name": {
+      "title": "Name",
+      "description": "The official name of the ledger.",
+      "type": "string",
+      "opencrypto-weight": 1
+    },
+    "type": {
+      "title": "Type",
+      "type": "string",
+      "enum": [
+        "blockchain",
+        "sidechain",
+        "payment-channels"
+      ]
+    },
+    "forked": {
+      "type": "boolean",
+      "title": "Is forked",
+      "description": "Indicator if this asset was forked from another asset."
+    },
+    "fork_properties": {
+      "type": "object",
+      "title": "Fork properties",
+      "properties": {
+        "parent": {
+          "title": "Parent asset",
+          "description": "Asset from which was this asset forked.",
+          "type": "string"
+        },
+        "block": {
+          "title": "Block number",
+          "description": "Number of first block which differs from parent.",
+          "type": "number"
+        },
+        "time": {
+          "title": "Fork timestamp",
+          "description": "Date and time of first block.",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "web": {
+      "title": "Web",
+      "desctiption": "Official web page of the project (format https://).",
+      "$ref": "https://schema.opencrypto.io/models/core#/definitions/links"
+    },
+    "start_date": {
+      "title": "Start Date",
+      "description": "The day when the assets began to be first activated (format YYYY/MM/DD).",
+      "type": "string",
+      "format": "date",
+      "opencrypto-weight": 1
+    },
+    "networks": {
+      "type": "array",
+      "title": "Networks",
+      "items": {
+        "$ref": "https://schema.opencrypto.io/models/network#/"
+      },
+      "opencrypto-weight": 1
+    },
+    "history": {
+      "$ref": "https://schema.opencrypto.io/models/core#/definitions/history"
+    },
+    "images": {
+      "$ref": "https://schema.opencrypto.io/models/core#/definitions/images",
+      "opencrypto-weight": 1
+    },
+    "webids": {
+      "$ref": "https://schema.opencrypto.io/models/core#/definitions/webids"
+    },
+    "resources": {
+      "$ref": "https://schema.opencrypto.io/models/core#/definitions/resources"
+    }
+  }
+}

--- a/models/network.json
+++ b/models/network.json
@@ -10,6 +10,12 @@
       "description": "Unique identifier (to be written in small letters - for internal usage only).",
       "type": "string"
     },
+    "pid": {
+      "title": "PID",
+      "description": "Project ID (generated).",
+      "type": "string",
+      "opencrypto-generated": true
+    },
     "name": {
       "title": "Name",
       "description": "Name of the network (eg. Mainnet, Testnet, Rinkeby).",

--- a/models/project.json
+++ b/models/project.json
@@ -31,33 +31,50 @@
       "$ref": "https://schema.opencrypto.io/models/core#/definitions/links",
       "opencrypto-weight": 1
     },
+    "ledgers": {
+      "title": "Ledgers",
+      "type": "array",
+      "items": {
+        "$ref": "https://schema.opencrypto.io/models/ledger#/"
+      },
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
+    },
     "assets": {
+      "title": "Assets",
       "type": "array",
       "items": {
         "$ref": "https://schema.opencrypto.io/models/asset#/"
       },
-      "opencrypto-weight": 1
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
     },
     "exchanges": {
+      "title": "Exchanges",
       "type": "array",
       "items": {
         "$ref": "https://schema.opencrypto.io/models/exchange#/"
-      }
+      },
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
     },
     "clients": {
+      "title": "Clients",
       "type": "array",
       "items": {
         "$ref": "https://schema.opencrypto.io/models/client#/"
-      }
+      },
+      "opencrypto-weight": 1,
+      "opencrypto-weight-min": 0
     },
     "team": {
       "$ref": "https://schema.opencrypto.io/models/core#/definitions/team",
       "opencrypto-weight": 1
     },
     "team_url": {
+      "title": "Team URL",
       "type": "string",
-      "format": "url",
-      "opencrypto-weight": 0.5
+      "format": "url"
     },
     "contacts": {
       "$ref": "https://schema.opencrypto.io/models/core#/definitions/contacts",


### PR DESCRIPTION
This PR introduces some important changes:
- New collection `Ledger` (under `Project`) - the goal is to differentiate between Assets (as money instrument) and Ledgers (blockchain technology)
  - Move `networks` section from Asset to Ledger
  - Remove of special object `asset.token_properties` - now we have `ledger` (required now for every assets), `contract_address` and `decimals` right on Asset
- Some basics added to `Exchange` model -  mainly `decentralized`, `user_security`, `apps`, `fees`
- New property `pid` (project-id?) on all models - for easy referencing of subtypes

resolve #6 